### PR TITLE
Improve mobile view and add dynamic repellents to contact page

### DIFF
--- a/src/common/components/Layout/BackgroundParticles/Particles.tsx
+++ b/src/common/components/Layout/BackgroundParticles/Particles.tsx
@@ -10,6 +10,7 @@ import { fragment, vertex } from './particle-material'
 import positionStore, { randomizeLocations } from './store'
 import { Circle, Point2d, Polygon, RepellentShape, isCircle } from './types'
 import {
+  PI2,
   escapeRadius,
   generateRectangleFromBoundingRect,
   generateRectangleFromCenter,
@@ -19,6 +20,7 @@ import {
   isPointInCircle,
   isPointInPolygon,
   projectWindowPointIntoViewport,
+  scaleWidthIntoViewport,
 } from './utils'
 
 const GetShaderMaterial: React.FC<{
@@ -89,18 +91,6 @@ const Particles: React.FC<Props> = ({ top, pathname }) => {
           vertices: generateStar(
             viewport.width < viewport.height ? viewport.width * 0.4 : viewport.height * 0.48,
             { x: 0, y: -viewportTop },
-          ),
-        },
-      ]
-    if (pathname === '/contact')
-      return [
-        {
-          vertices: generateRectangleFromCenter(
-            { x: 0, y: -viewportTop / 2 },
-            viewport.height -
-              (viewport.height > viewport.width ? viewport.height / 10 : viewport.width / 10),
-            viewport.width -
-              (viewport.height > viewport.width ? viewport.height / 10 : viewport.width / 10),
           ),
         },
       ]
@@ -197,10 +187,10 @@ const Particles: React.FC<Props> = ({ top, pathname }) => {
         case RepellentShape.Circle:
           return {
             ...projectWindowPointIntoViewport(
-              { x: (right - left) / 2, y: (bottom - top) / 2 },
+              { x: (right + left) / 2, y: (top + bottom) / 2 },
               viewportScale,
             ),
-            radius: (bottom - top) / 2,
+            radius: scaleWidthIntoViewport((right - left) / 2, viewportScale),
           }
         case RepellentShape.Rectangle:
           return {
@@ -211,8 +201,8 @@ const Particles: React.FC<Props> = ({ top, pathname }) => {
         case RepellentShape.Star:
           return {
             vertices: generateStar(bottom - top, {
-              x: (right - left) / 2,
-              y: (bottom - top) / 2,
+              x: (right + left) / 2,
+              y: (bottom + top) / 2,
             }).map(point => projectWindowPointIntoViewport(point, viewportScale)),
           }
         default:
@@ -276,7 +266,7 @@ const Particles: React.FC<Props> = ({ top, pathname }) => {
         const particleWasRepelled = allRepellentShapes.some((repellent, repellentIndex) => {
           if (isCircle(repellent)) {
             if (repellent.radius > 0 && isPointInCircle(currentPoint, repellent)) {
-              pas.setX(i, escapeRadius({ ...currentPoint, angle, turnV }, repellent, 1.5))
+              pas.setX(i, escapeRadius({ ...currentPoint, angle, turnV }, repellent, PI2))
               return true
             }
           } else {
@@ -301,7 +291,7 @@ const Particles: React.FC<Props> = ({ top, pathname }) => {
                       2,
                     radius: Math.max.apply(Math, [viewport.width, viewport.height]),
                   },
-                  1.5,
+                  PI2,
                 ),
               )
               return true

--- a/src/common/components/Layout/BackgroundParticles/utils.ts
+++ b/src/common/components/Layout/BackgroundParticles/utils.ts
@@ -222,6 +222,16 @@ export const projectWindowPointIntoViewport = (
     (point.y - 0) * ((-viewportScale.yMax - -viewportScale.yMin) / (window.innerHeight - 0)), // three.js coordinate system y axis is inverted to the window's coordinate system
 })
 
+export const scaleWidthIntoViewport = (
+  width: number,
+  viewportScale: {
+    xMin: number
+    xMax: number
+    yMin: number
+    yMax: number
+  },
+) => width * ((viewportScale.xMax - viewportScale.xMin) / (window.innerWidth - 0))
+
 export const getVisibleParticleRepellents = () => {
   const allRepellents = document.querySelectorAll('*[data-repel-particles="true"]')
   const visibleRepellents = Array.from(allRepellents).filter(repellent => {

--- a/src/contact/pages/ContactPageContent.tsx
+++ b/src/contact/pages/ContactPageContent.tsx
@@ -1,66 +1,18 @@
 import React from 'react'
-import { BsGithub } from 'react-icons/bs'
-import { MdEmail, MdLocalPhone, MdMessage } from 'react-icons/md'
-import { RiLinkedinBoxFill } from 'react-icons/ri'
-import { useTheme } from 'styled-components'
+import { SOCIALS } from './constants'
 import { ContactText, SocialLink, SocialLinks, Wrapper } from './style'
 
-interface Social {
-  site: string
-  href: string
-  icon: React.ReactNode
-  text: string
-}
-
-const ContactPageContent: React.FC = () => {
-  const theme = useTheme()
-
-  const SOCIALS: Social[] = [
-    {
-      site: 'LinkedIn',
-      href: 'https://www.linkedin.com/in/pcdevri/',
-      icon: <RiLinkedinBoxFill size="10rem" color={theme.secondary} />,
-      text: 'https://www.linkedin.com/in/pcdevri/',
-    },
-    {
-      site: 'GitHub',
-      href: 'https://github.com/PatrickDeVries',
-      icon: <BsGithub size="10rem" color={theme.secondary} />,
-      text: 'https://github.com/PatrickDeVries',
-    },
-    {
-      site: 'Email',
-      href: 'mailto:pcdevri@gmail.com',
-      icon: <MdEmail size="10rem" color={theme.secondary} />,
-      text: 'pcdevri@gmail.com',
-    },
-    {
-      site: 'Text',
-      href: 'sms:8178881514',
-      icon: <MdMessage size="10rem" color={theme.secondary} />,
-      text: '(817) 888-1514',
-    },
-    {
-      site: 'Phone',
-      href: 'tel:8178881514',
-      icon: <MdLocalPhone size="10rem" color={theme.secondary} />,
-      text: '(817) 888-1514',
-    },
-  ]
-
-  return (
-    <Wrapper>
-      <ContactText>Contact me:</ContactText>
-      <SocialLinks>
-        {SOCIALS.map(social => (
-          <SocialLink key={social.site} as={'a'} href={social.href}>
-            {social.icon}
-            <div>{social.text}</div>
-          </SocialLink>
-        ))}
-      </SocialLinks>
-    </Wrapper>
-  )
-}
+const ContactPageContent: React.FC = () => (
+  <Wrapper>
+    <ContactText data-repel-particles>Contact me:</ContactText>
+    <SocialLinks>
+      {SOCIALS.map(social => (
+        <SocialLink key={social.site} as="a" href={social.href}>
+          {social.icon}
+        </SocialLink>
+      ))}
+    </SocialLinks>
+  </Wrapper>
+)
 
 export default ContactPageContent

--- a/src/contact/pages/constants.tsx
+++ b/src/contact/pages/constants.tsx
@@ -1,0 +1,38 @@
+import { RepellentShape } from '@/common/components/Layout/BackgroundParticles/types'
+import { BsGithub } from 'react-icons/bs'
+import { MdEmail, MdLocalPhone, MdMessage } from 'react-icons/md'
+import { RiLinkedinBoxFill } from 'react-icons/ri'
+import { Social } from './types'
+
+export const SOCIALS: Social[] = [
+  {
+    site: 'LinkedIn',
+    href: 'https://www.linkedin.com/in/pcdevri/',
+    icon: <RiLinkedinBoxFill data-repel-particles />,
+    text: 'https://www.linkedin.com/in/pcdevri/',
+  },
+  {
+    site: 'GitHub',
+    href: 'https://github.com/PatrickDeVries',
+    icon: <BsGithub data-repel-particles data-repel-shape={RepellentShape.Circle} />,
+    text: 'https://github.com/PatrickDeVries',
+  },
+  {
+    site: 'Email',
+    href: 'mailto:pcdevri@gmail.com',
+    icon: <MdEmail data-repel-particles />,
+    text: 'pcdevri@gmail.com',
+  },
+  {
+    site: 'Text',
+    href: 'sms:8178881514',
+    icon: <MdMessage data-repel-particles />,
+    text: '(817) 888-1514',
+  },
+  {
+    site: 'Phone',
+    href: 'tel:8178881514',
+    icon: <MdLocalPhone data-repel-particles />,
+    text: '(817) 888-1514',
+  },
+]

--- a/src/contact/pages/style.ts
+++ b/src/contact/pages/style.ts
@@ -1,41 +1,53 @@
+import { RepellentShape } from '@/common/components/Layout/BackgroundParticles/types'
 import styled from 'styled-components'
 
 export const Wrapper = styled.div`
   padding: 3rem;
-  margin-top: auto;
-  margin-bottom: auto;
+  height: 100%;
+
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
+  gap: 3rem;
 `
 
 export const ContactText = styled.div`
   font-size: 2rem;
+  padding: 1rem;
 `
 
 export const SocialLinks = styled.div`
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 3rem;
   display: flex;
-  gap: 2rem;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: center;
+  align-items: center;
+  gap: 2rem;
 `
 
 export const SocialLink = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
 
-  text-decoration: none;
+  color: ${({ theme }) => theme.secondary};
 
-  color: ${({ theme }) => theme.text};
+  svg {
+    height: 10rem;
+    width: 10rem;
+  }
 
-  &:hover {
-    text-decoration: underline;
+  svg[data-repel-shape=${RepellentShape.Circle}] {
+    padding: 1rem;
+  }
+
+  &:hover,
+  &:focus {
+    outline: none;
+    color: ${({ theme }) => theme.primary};
+  }
+  &:focus {
+    filter: drop-shadow(-1px -1px 0px black) drop-shadow(1px -1px 0px black)
+      drop-shadow(1px 1px 0px black) drop-shadow(-1px 1px 0px black);
   }
 `

--- a/src/contact/pages/types.ts
+++ b/src/contact/pages/types.ts
@@ -1,0 +1,6 @@
+export interface Social {
+  site: string
+  href: string
+  icon: React.ReactNode
+  text: string
+}

--- a/src/portfolio/pages/GithubStats/GithubStats.tsx
+++ b/src/portfolio/pages/GithubStats/GithubStats.tsx
@@ -1,4 +1,3 @@
-import { RepellentShape } from '@/common/components/Layout/BackgroundParticles/types'
 import React from 'react'
 import { useTheme } from 'styled-components'
 import { Wrapper } from './style'
@@ -17,7 +16,6 @@ const GithubStats: React.FC = () => {
       )}&bg_color=${formatColorArg(theme.backgroundHighlight)}&hide_border=true&hide=issues`}
       alt="GitHub user stats for patrickdevries"
       data-repel-particles
-      data-repel-shape={RepellentShape.Rectangle}
     />
   )
 }

--- a/src/portfolio/pages/GithubStats/style.ts
+++ b/src/portfolio/pages/GithubStats/style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 export const Wrapper = styled.img`
   width: calc(50% - 1rem);
-  height: 25rem;
+  height: 25%;
 
   border: 1px solid ${({ theme }) => theme.secondary};
   border-radius: 0.5rem;

--- a/src/portfolio/pages/PortfolioPageContent.tsx
+++ b/src/portfolio/pages/PortfolioPageContent.tsx
@@ -8,8 +8,8 @@ const PortfolioPageContent: React.FC = () => (
   <Wrapper>
     {Object.keys(MY_WORK).map(section => (
       <section key={`${section}-section`}>
-        <SectionHeader>{section}:</SectionHeader>
-        <WorkItems key={`${section}-work-items`}>
+        <SectionHeader data-repel-particles>{section}:</SectionHeader>
+        <WorkItems>
           {MY_WORK[section].map(item => (
             <WorkCard key={item.header} item={item} />
           ))}

--- a/src/portfolio/pages/WorkCard/WorkCard.tsx
+++ b/src/portfolio/pages/WorkCard/WorkCard.tsx
@@ -1,4 +1,3 @@
-import { RepellentShape } from '@/common/components/Layout/BackgroundParticles/types'
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { WorkItem } from '../types'
@@ -15,7 +14,6 @@ const WorkCard: React.FC<Props> = ({ item }) => (
     to={item.to}
     $isLink={!!item.href || !!item.to}
     data-repel-particles
-    data-repel-shape={RepellentShape.Rectangle}
   >
     <HeaderText>{item.header}</HeaderText>
     <BodySection>

--- a/src/portfolio/pages/WorkCard/style.ts
+++ b/src/portfolio/pages/WorkCard/style.ts
@@ -13,7 +13,6 @@ export const StyledCard = styled.div<{ $isLink: boolean }>`
 
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   gap: 1rem;
 
   background-color: ${({ theme }) => theme.backgroundHighlight};
@@ -32,38 +31,43 @@ export const StyledCard = styled.div<{ $isLink: boolean }>`
 
   text-decoration: none;
 
-  ${({ $isLink }) =>
+  ${({ $isLink, theme }) =>
     $isLink &&
     css`
-      &:hover {
+      ${HeaderText} {
+        text-decoration: underline;
+      }
+
+      &:hover,
+      &:focus {
         ${HeaderText} {
-          text-decoration: underline;
+          color: ${theme.primary};
         }
+        border: 1px solid ${theme.primary};
+        outline: none;
       }
     `}
 `
 
 export const BodySection = styled.div`
+  display: block;
+
+  padding: 1rem;
   width: 100%;
 
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-
   font-size: 1.2rem;
-
-  ${MOBILE} {
-    flex-direction: column;
-    align-items: center;
-  }
-  padding: 1rem;
 `
 
 export const ScalingImg = styled.img`
   display: block;
+
+  float: left;
+  padding: 1rem;
+
   max-height: 20vh;
   max-width: 100%;
-  object-fit: cover;
+
+  object-fit: contain;
   border-radius: 0.5rem;
 `
 
@@ -77,9 +81,11 @@ export const BodyText = styled.p`
 `
 
 export const TagSection = styled.div`
+  height: 100%;
   width: 100%;
 
   display: flex;
+  align-items: flex-start;
   flex-flow: row wrap-reverse;
   justify-content: flex-start;
   gap: 0.5rem;

--- a/src/portfolio/pages/style.ts
+++ b/src/portfolio/pages/style.ts
@@ -5,16 +5,16 @@ export const Wrapper = styled.div`
   padding: 2rem;
 
   ${TABLET} {
-    padding: 1rem;
+    padding: 1.5rem;
   }
 
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 2rem;
 `
 
 export const SectionHeader = styled.h2`
-  width: 100%;
+  width: fit-content;
   padding: 1rem;
   color: ${({ theme }) => theme.primary};
 


### PR DESCRIPTION
Closes #13 
- Wrap text around portfolio images
  - ![image](https://github.com/PatrickDeVries/portfolio-site/assets/39521214/ded8e715-2a03-48b6-ac88-35fafb942d1e)
 - Tweak padding
 - Add dynamic repellents to contact page icons