### PR TITLE
Clean up particle movement logic

### DIFF
--- a/src/background-editor/BackgroundEditorRouter.tsx
+++ b/src/background-editor/BackgroundEditorRouter.tsx
@@ -1,8 +1,15 @@
+import { FallbackMessage } from '@/common/providers/RouteProvider/style'
 import React from 'react'
 import { RouteObject, useRoutes } from 'react-router-dom'
 import BackgroundEditorPage from './pages'
 
-const ROUTES: RouteObject[] = [{ path: '/', element: <BackgroundEditorPage /> }]
+const ROUTES: RouteObject[] = [
+  { path: '/', element: <BackgroundEditorPage /> },
+  {
+    path: '/*',
+    element: <FallbackMessage>404 | not found</FallbackMessage>,
+  },
+]
 
 const BackgroundEditorRouter: React.FC = () => useRoutes(ROUTES)
 

--- a/src/background-editor/components/control-cards/LavaLampControlFields.tsx
+++ b/src/background-editor/components/control-cards/LavaLampControlFields.tsx
@@ -11,6 +11,7 @@ import lavaLampSettings, {
 import { RepellentShape } from '@/common/components/Layout/Background/types'
 import RangeSlider from '@/common/components/RangeSlider'
 import Select from '@/common/components/Select'
+import { useWindowListener } from '@yobgob/too-many-hooks'
 import React from 'react'
 import { useSnapshot } from 'valtio'
 import { formatMouseShape } from './formatters'
@@ -18,6 +19,16 @@ import { WrappingRow } from './style'
 
 const LavaLampControlFields: React.FC = () => {
   const lavaLampSnap = useSnapshot(lavaLampSettings)
+
+  useWindowListener('keyup', event => {
+    if (event.key === '=') {
+      lavaLampSettings.mouseSize =
+        lavaLampSettings.mouseSize + 0.5 < 5 ? lavaLampSettings.mouseSize + 0.5 : 5
+    } else if (event.key === '-') {
+      lavaLampSettings.mouseSize =
+        lavaLampSettings.mouseSize - 0.5 > 0 ? lavaLampSettings.mouseSize - 0.5 : 0
+    }
+  })
 
   return (
     <>

--- a/src/background-editor/components/control-cards/ParticleControlFields.tsx
+++ b/src/background-editor/components/control-cards/ParticleControlFields.tsx
@@ -11,6 +11,7 @@ import particleSettings, {
 import { RepellentShape } from '@/common/components/Layout/Background/types'
 import RangeSlider from '@/common/components/RangeSlider'
 import Select from '@/common/components/Select'
+import { useWindowListener } from '@yobgob/too-many-hooks'
 import React from 'react'
 import { useSnapshot } from 'valtio'
 import { formatMouseShape } from './formatters'
@@ -18,6 +19,16 @@ import { WrappingRow } from './style'
 
 const ParticleControlFields: React.FC = () => {
   const particleSnap = useSnapshot(particleSettings)
+
+  useWindowListener('keyup', event => {
+    if (event.key === '=') {
+      particleSettings.mouseSize =
+        particleSettings.mouseSize + 0.5 < 5 ? particleSettings.mouseSize + 0.5 : 5
+    } else if (event.key === '-') {
+      particleSettings.mouseSize =
+        particleSettings.mouseSize - 0.5 > 0 ? particleSettings.mouseSize - 0.5 : 0
+    }
+  })
 
   return (
     <>

--- a/src/common/components/Layout/Background/LavaLamp/LavaLamp.tsx
+++ b/src/common/components/Layout/Background/LavaLamp/LavaLamp.tsx
@@ -52,6 +52,9 @@ const LavaLamp: React.FC<Props> = ({ top }) => {
     top: viewportTop,
   }
 
+  const { mouseShape, mouseSize, particleCount } = useSnapshot(lavaLampSettings)
+  const { scaledParticleCollisionRadius } = useSnapshot(derivedLavaLampSettings)
+
   const {
     positions: initialPositions,
     temperatures: initialTemperatures,
@@ -61,7 +64,6 @@ const LavaLamp: React.FC<Props> = ({ top }) => {
   const pointsRef = useRef<Points | null>(null)
 
   const mouse = usePoint2dMouse(viewport)
-  const { mouseShape, mouseSize } = useSnapshot(lavaLampSettings)
   const { pathname } = useLocation()
 
   const updatePositions = () => {
@@ -86,16 +88,16 @@ const LavaLamp: React.FC<Props> = ({ top }) => {
       const pgvs = pointsRef.current.geometry.getAttribute('goalVelocity')
 
       const pointBoundingSpheres = Array.from(
-        { length: lavaLampSettings.particleCount },
+        { length: particleCount },
         (_, index) =>
           new Sphere(
             new Vector3(pps.getX(index), pps.getY(index), pps.getZ(index)),
-            derivedLavaLampSettings.scaledParticleCollisionRadius,
+            scaledParticleCollisionRadius,
           ),
       )
 
       // update each particle's position
-      for (let i = 0, l = lavaLampSettings.particleCount; i < l; i++) {
+      for (let i = 0, l = particleCount; i < l; i++) {
         let temperature = pts.getX(i)
         const particleGoalHorizontalVelocity = pgvs.getX(i)
 
@@ -255,7 +257,7 @@ const LavaLamp: React.FC<Props> = ({ top }) => {
 
     if (pointsRef.current) {
       lavaLampPositionStore.pointsRef = pointsRef
-      pointsRef.current.geometry.setDrawRange(0, lavaLampSettings.particleCount)
+      pointsRef.current.geometry.setDrawRange(0, particleCount)
     }
   })
 

--- a/src/common/components/Layout/Background/LavaLamp/LavaLamp.tsx
+++ b/src/common/components/Layout/Background/LavaLamp/LavaLamp.tsx
@@ -251,12 +251,10 @@ const LavaLamp: React.FC<Props> = ({ top }) => {
         pts.setX(i, temperature - temperatureChange)
       }
 
-      pointsRef.current.geometry.setAttribute('position', pps)
-      pointsRef.current.geometry.setAttribute('velocity', pvs)
-      pointsRef.current.geometry.setAttribute('temperature', pts)
       pointsRef.current.geometry.attributes.position.needsUpdate = true
       pointsRef.current.geometry.attributes.velocity.needsUpdate = true
       pointsRef.current.geometry.attributes.temperature.needsUpdate = true
+      pointsRef.current.geometry.attributes.goalVelocity.needsUpdate = true
     }
   }
 

--- a/src/common/components/Layout/Background/Particles/ParticleShaderMaterial.tsx
+++ b/src/common/components/Layout/Background/Particles/ParticleShaderMaterial.tsx
@@ -15,10 +15,10 @@ export const vertex = `
   void main() {
       rightness = (position.x - bboxMin) / (bboxMax - bboxMin);
       vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
-      gl_Position = projectionMatrix * modelViewPosition;    
+      gl_Position = projectionMatrix * modelViewPosition;
       gl_PointSize = pointSize;   
-  }
-  `
+    }
+    `
 
 export const fragment = `
     uniform vec3 colorA; 

--- a/src/common/components/Layout/Background/Particles/Particles.tsx
+++ b/src/common/components/Layout/Background/Particles/Particles.tsx
@@ -34,12 +34,15 @@ const Particles: React.FC<Props> = ({ top }) => {
     }),
     [viewport.height, viewport.width],
   )
-
   particlesPositionStore.viewport = {
     width: viewport.width,
     height: viewport.height,
     top: viewportTop,
   }
+
+  const { mouseShape, mouseSize, particleCount, vVar, baseV, turnVar, baseTurnV, freeThinkers } =
+    useSnapshot(particleSettings)
+
   const {
     positions: initialPositions,
     velocities: initialVelocities,
@@ -49,7 +52,6 @@ const Particles: React.FC<Props> = ({ top }) => {
   const pointsRef = useRef<Points | null>(null)
 
   const mouse = usePoint2dMouse(viewport)
-  const { mouseShape, mouseSize } = useSnapshot(particleSettings)
   const { pathname } = useLocation()
 
   const updatePositions = () => {
@@ -73,10 +75,10 @@ const Particles: React.FC<Props> = ({ top }) => {
       const pas = pointsRef.current.geometry.getAttribute('angle')
 
       // update each particle's position
-      for (let i = 0, l = particleSettings.particleCount; i < l; i++) {
+      for (let i = 0, l = particleCount; i < l; i++) {
         let angle = pas.getX(i)
-        const velocity = pvs.getX(i) * particleSettings.vVar + particleSettings.baseV
-        const turnVelocity = pvs.getY(i) * particleSettings.turnVar + particleSettings.baseTurnV
+        const velocity = pvs.getX(i) * vVar + baseV
+        const turnVelocity = pvs.getY(i) * turnVar + baseTurnV
         const previousPosition = { x: pps.getX(i), y: pps.getY(i) }
 
         const newPosition = {
@@ -139,8 +141,8 @@ const Particles: React.FC<Props> = ({ top }) => {
           )
         }
         // if not reflected and there are no free thinkers
-        else if (particleSettings.freeThinkers === 0) {
-          const targetParticleIndex = i === 0 ? particleSettings.particleCount - 1 : i - 1
+        else if (freeThinkers === 0) {
+          const targetParticleIndex = i === 0 ? particleCount - 1 : i - 1
           const targetParticleLocation = {
             x: pps.getX(targetParticleIndex),
             y: pps.getY(targetParticleIndex),
@@ -152,10 +154,7 @@ const Particles: React.FC<Props> = ({ top }) => {
           angle = getNewAngle(angle, goalAngle, turnVelocity)
         }
         // if not reflected, there are free thinkers, and this particle is not one
-        else if (
-          i > 0 &&
-          i % Math.ceil(particleSettings.particleCount / particleSettings.freeThinkers) !== 0
-        ) {
+        else if (i > 0 && i % Math.ceil(particleCount / freeThinkers) !== 0) {
           const targetParticleLocation = {
             x: pps.getX(i - 1),
             y: pps.getY(i - 1),
@@ -181,7 +180,7 @@ const Particles: React.FC<Props> = ({ top }) => {
 
     if (pointsRef.current) {
       particlesPositionStore.pointsRef = pointsRef
-      pointsRef.current.geometry.setDrawRange(0, particleSettings.particleCount) // only draw particles [0-`particleCount`)
+      pointsRef.current.geometry.setDrawRange(0, particleCount) // only draw particles [0-`particleCount`)
     }
   })
 

--- a/src/common/components/Layout/Background/Particles/Particles.tsx
+++ b/src/common/components/Layout/Background/Particles/Particles.tsx
@@ -212,7 +212,7 @@ const Particles: React.FC<Props> = ({ top }) => {
     }
   })
 
-  if (initialPositions.length < MAX_PARTICLES * 3) {
+  if (initialPositions.length < MAX_PARTICLES * 2) {
     return null
   }
 
@@ -223,13 +223,13 @@ const Particles: React.FC<Props> = ({ top }) => {
           attach="attributes-position"
           count={MAX_PARTICLES}
           array={new Float32Array(initialPositions)}
-          itemSize={3}
+          itemSize={2}
         />
         <bufferAttribute
           attach="attributes-velocity"
           count={MAX_PARTICLES}
           array={new Float32Array(initialVelocities)}
-          itemSize={3}
+          itemSize={2}
         />
         <bufferAttribute
           attach="attributes-angle"

--- a/src/common/components/Layout/Background/Particles/Particles.tsx
+++ b/src/common/components/Layout/Background/Particles/Particles.tsx
@@ -1,5 +1,4 @@
 import { useFrame, useThree } from '@react-three/fiber'
-import { useWindowListener } from '@yobgob/too-many-hooks'
 import React, { useMemo, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Points } from 'three'
@@ -24,16 +23,6 @@ type Props = {
 }
 
 const Particles: React.FC<Props> = ({ top }) => {
-  useWindowListener('keyup', event => {
-    if (event.key === '=') {
-      particleSettings.mouseSize =
-        particleSettings.mouseSize + 0.5 < 5 ? particleSettings.mouseSize + 0.5 : 5
-    } else if (event.key === '-') {
-      particleSettings.mouseSize =
-        particleSettings.mouseSize - 0.5 > 0 ? particleSettings.mouseSize - 0.5 : 0
-    }
-  })
-
   const viewport = useThree(rootState => rootState.viewport)
   const viewportTop = top * (viewport.height / window.innerHeight)
   const viewportScale = useMemo(

--- a/src/common/components/Layout/Background/Particles/position-store/utils.ts
+++ b/src/common/components/Layout/Background/Particles/position-store/utils.ts
@@ -17,9 +17,8 @@ export const generateRandomParticleData = (): {
       Math.random() * particlesPositionStore.viewport.height -
         particlesPositionStore.viewport.height / 2 -
         particlesPositionStore.viewport.top,
-      0,
     )
-    velocities.push(Math.random(), Math.random(), 0)
+    velocities.push(Math.random(), Math.random())
     let newA = Math.random() * 2 * Math.PI
     if (
       newA < 0.01 ||
@@ -45,8 +44,8 @@ export const randomizeParticleData = () => {
     const pas = particlesPositionStore.pointsRef.current.geometry.getAttribute('angle')
 
     for (let i = 0; i < MAX_PARTICLES; i++) {
-      pps.setXYZ(i, positions[i * 3], positions[i * 3 + 1], 0)
-      pvs.setXYZ(i, velocities[i * 3], velocities[i * 3 + 1], 0)
+      pps.setXY(i, positions[i * 2], positions[i * 2 + 1])
+      pvs.setXY(i, velocities[i * 2], velocities[i * 2 + 1])
       pas.setX(i, angles[i])
     }
     particlesPositionStore.pointsRef.current.geometry.setAttribute('position', pps)

--- a/src/common/components/Layout/Background/Particles/position-store/utils.ts
+++ b/src/common/components/Layout/Background/Particles/position-store/utils.ts
@@ -17,6 +17,7 @@ export const generateRandomParticleData = (): {
       Math.random() * particlesPositionStore.viewport.height -
         particlesPositionStore.viewport.height / 2 -
         particlesPositionStore.viewport.top,
+      0,
     )
     velocities.push(Math.random(), Math.random())
     let newA = Math.random() * 2 * Math.PI
@@ -44,7 +45,7 @@ export const randomizeParticleData = () => {
     const pas = particlesPositionStore.pointsRef.current.geometry.getAttribute('angle')
 
     for (let i = 0; i < MAX_PARTICLES; i++) {
-      pps.setXY(i, positions[i * 2], positions[i * 2 + 1])
+      pps.setXYZ(i, positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2])
       pvs.setXY(i, velocities[i * 2], velocities[i * 2 + 1])
       pas.setX(i, angles[i])
     }

--- a/src/common/components/Layout/Background/types.ts
+++ b/src/common/components/Layout/Background/types.ts
@@ -27,6 +27,8 @@ export type Star = {
 
 export type Polygon = Rectangle | Star
 
+export type Repellent = { shape: Circle | Polygon; mins: Point2d; maxes: Point2d; center: Point2d }
+
 export enum RepellentShape {
   Circle = 'CIRCLE',
   Rectangle = 'RECTANGLE',

--- a/src/common/components/Layout/Background/utils.ts
+++ b/src/common/components/Layout/Background/utils.ts
@@ -504,21 +504,6 @@ export const getWindowBoundsCollisions = ({
   const isAtLeft = position.x < minX
   const hasCollidedWithLeft = isAtLeft && xVelocity < 0
 
-  // if (isAtBottom && yVelocity < 0)
-  //   console.log(
-  //     isAtTop,
-  //     hasCollidedWithTop,
-  //     isAtRight,
-  //     hasCollidedWithRight,
-  //     isAtBottom,
-  //     hasCollidedWithBottom,
-  //     isAtLeft,
-  //     hasCollidedWithLeft,
-  //     position,
-  //     xVelocity,
-  //     yVelocity,
-  //   )
-
   return {
     isAtTop,
     hasCollidedWithTop,

--- a/src/common/providers/RouteProvider/Router.tsx
+++ b/src/common/providers/RouteProvider/Router.tsx
@@ -4,11 +4,10 @@ import HomePages from '@/home'
 import PortfolioPages from '@/portfolio'
 import React from 'react'
 import { RouteObject, useRoutes } from 'react-router-dom'
-import { FallbackMessage } from './style'
 
 const ROUTES: RouteObject[] = [
   {
-    path: '/',
+    path: '/*',
     element: <HomePages />,
   },
   {
@@ -22,10 +21,6 @@ const ROUTES: RouteObject[] = [
   {
     path: '/portfolio/*',
     element: <PortfolioPages />,
-  },
-  {
-    path: '/*',
-    element: <FallbackMessage>404 | not found</FallbackMessage>,
   },
 ]
 

--- a/src/contact/ContactRouter.tsx
+++ b/src/contact/ContactRouter.tsx
@@ -1,8 +1,15 @@
+import { FallbackMessage } from '@/common/providers/RouteProvider/style'
 import React from 'react'
 import { RouteObject, useRoutes } from 'react-router-dom'
 import ContactPage from './pages'
 
-const ROUTES: RouteObject[] = [{ path: '/', element: <ContactPage /> }]
+const ROUTES: RouteObject[] = [
+  { path: '/', element: <ContactPage /> },
+  {
+    path: '/*',
+    element: <FallbackMessage>404 | not found</FallbackMessage>,
+  },
+]
 
 const ContactRouter: React.FC = () => useRoutes(ROUTES)
 

--- a/src/home/HomeRouter.tsx
+++ b/src/home/HomeRouter.tsx
@@ -1,8 +1,15 @@
+import { FallbackMessage } from '@/common/providers/RouteProvider/style'
 import React from 'react'
 import { RouteObject, useRoutes } from 'react-router-dom'
 import HomePage from './pages'
 
-const ROUTES: RouteObject[] = [{ path: '/', element: <HomePage /> }]
+const ROUTES: RouteObject[] = [
+  { path: '/', element: <HomePage /> },
+  {
+    path: '/*',
+    element: <FallbackMessage>404 | not found</FallbackMessage>,
+  },
+]
 
 const HomeRouter: React.FC = () => useRoutes(ROUTES)
 

--- a/src/portfolio/PortfolioRouter.tsx
+++ b/src/portfolio/PortfolioRouter.tsx
@@ -1,3 +1,4 @@
+import { FallbackMessage } from '@/common/providers/RouteProvider/style'
 import React from 'react'
 import { RouteObject, useRoutes } from 'react-router-dom'
 import PortfolioPage from './pages'
@@ -5,7 +6,15 @@ import SSEOPage from './pages/sseo'
 
 const ROUTES: RouteObject[] = [
   { path: '/', element: <PortfolioPage /> },
-  { path: 'sseo', element: <SSEOPage /> },
+  { path: '/sseo', element: <SSEOPage /> },
+  {
+    path: '/sseo/*',
+    element: <FallbackMessage>404 | not found</FallbackMessage>,
+  },
+  {
+    path: '/*',
+    element: <FallbackMessage>404 | not found</FallbackMessage>,
+  },
 ]
 
 const PortfolioRouter: React.FC = () => useRoutes(ROUTES)


### PR DESCRIPTION
Closes #44 

- Rework repellent information calculations to be faster and produce a `Repellent` object
- Memoize points and reintroduce react state to lava lamp and particles
- Use snapshots of settings for both backgrounds
- Abstract logic for window boundary checking
- Rename variables and add comments to particle movement code
- Fix 404 routing